### PR TITLE
Change to pyproject toml so setuptools can find submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+##[0.6.2]
+* Fix to broken import of submodule `tasks/`. 
+
+## [0.6.0]
 * Updating Documentation ([#11](https://github.com/environmental-forecasting/model-ensembler/issues/11), [#22](https://github.com/environmental-forecasting/model-ensembler/issues/22)):
     * Changed from sphinx to [mkdocs](https://www.mkdocs.org/), in line with other [environmental-forecasting](https://github.com/environmental-forecasting) tools.
     * API/Reference automatically generated using [mkdocstrings](https://mkdocstrings.github.io/) and [mkdocs-autoapi](https://mkdocs-autoapi.readthedocs.io/en/latest/).

--- a/model_ensembler/__init__.py
+++ b/model_ensembler/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Byrne"""
 __email__ = 'jambyr@bas.ac.uk'
-__version__ = '0.6.1'
+__version__ = '0.6.2'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["."]
-packages = ["model_ensembler*"]
+include = ["model_ensembler*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "model_ensembler.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,10 @@ model_ensemble_check = "model_ensembler.cli:check"
 
 [tool.setuptools]
 include-package-data = true
-packages = ["model_ensembler"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+packages = ["model_ensembler*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "model_ensembler.__version__"}


### PR DESCRIPTION
Small change to `pyproject.toml` to make sure setuptools can find the submodules.